### PR TITLE
Fix the results and make the report readable

### DIFF
--- a/_posts/2015-09-20-myles-cullen-and-george-harrison.md
+++ b/_posts/2015-09-20-myles-cullen-and-george-harrison.md
@@ -5,14 +5,19 @@ location: Phoenix Park
 The 2015 edition of the LVAC 10km (men’s) and 5Km (women’s) championship took
 place in perfect conditions on the Acres lap. The club championship, which
 incorporates the Myles Cullen and George Harrison memorial trophies was a
-keenly contested event with many battles taking places in both races. Leona
-O’Reily led home the women’s race in a time of 18:22 followed by a very strong
+keenly contested event with many battles taking places in both races.
+
+Leona O’Reilly led home the women’s race in a time of 18:22 followed by a very strong
 run from Aileen Gittens who is coming back into some fine form. Síle Carroll
-completed the medal winners for the womens. Peter Arthur ran a strong race in
+completed the medal winners for the womens.
+
+Peter Arthur ran a strong race in
 34:09 leading from the gun to tape. Brendan Beere finished second (35.05) and
 Ciaran Reilly and Chris Morgan battled it out on the last lap with positions
 altering coming into the final stretch and Ciaran emerged victorious to grab
-bronze. Well done to all new members who competed the tough lap and some fine
+bronze.
+
+Well done to all new members who competed the tough lap and some fine
 performances were evident in both races. Presentations of the club championship
 medals and the memorial trophies took place after the race in Gael Scoil
 Inchicore with members of the Harrison and Cullen family in attendance.

--- a/_races/2015-09-20-myles-cullen-10k.md
+++ b/_races/2015-09-20-myles-cullen-10k.md
@@ -3,6 +3,7 @@ title: Myles Cullen 10k
 latitude: 53.348499
 longitude: -6.318000
 date: 2015-09-20 11:30
+results:
   - place: 1
     name: Peter Arthurs
     finish_time: 34m 09s


### PR DESCRIPTION
The men's results were missing a line.

The race report was nigh on unreadable