### PR TITLE
Fix the map encoding

### DIFF
--- a/_layouts/race.html
+++ b/_layouts/race.html
@@ -42,7 +42,7 @@ layout: base
     attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
   }).addTo(map);
   L.marker([{{ page.latitude }}, {{ page.longitude }}]).addTo(map)
-  .bindPopup('{{ page.title }}')
+  .bindPopup("{{ page.title }}")
   .openPopup();
 </script>
 


### PR DESCRIPTION
Changes from using a single quote to double quotes. Previously, when there was an apostrophe in the page title, it caused an error and stopped the map from showing. This PR fixes that.