### PR TITLE
Only include google analytics if running in production

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -55,6 +55,7 @@
     <script src="//blueimp.github.io/Gallery/js/jquery.blueimp-gallery.min.js"></script>
     <script src="/assets/js/bootstrap.js"></script>
     <script src="/assets/js/bootstrap-image-gallery.min.js"></script>
+    {% if jekyll.environment == "production" %}
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
           (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -65,5 +66,6 @@
       ga('send', 'pageview');
 
     </script>
+    {% endif %}
   </body>
 </html>


### PR DESCRIPTION
Using `jekyll.environment` to check for the production environment.