### PR TITLE
Removes the open nights banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,6 @@ redirect_from:
     &nbsp;
   </div>
 </div>
-{% include open-night-banner.html %}
 <div class="row content">
   <div class="col-md-4">
     <h2>Interested in running?</h2>


### PR DESCRIPTION
September is over, so remove the open nights banner from the front page.