### PR TITLE
Adds tests for race results times

### DIFF
--- a/tests/race_results_test.rb
+++ b/tests/race_results_test.rb
@@ -1,0 +1,39 @@
+require_relative "test_helper"
+
+class RaceResultsTest < Blog::Test
+  def test_correct_field_name
+    finish_time = []
+
+    races.each do |filename|
+      yaml = YAML.load_file(filename)
+      if yaml.has_key?('results')
+        yaml['results'].each do |result|
+          finish_time << filename unless result.has_key?('finish_time')
+        end
+      end
+    end
+
+    assert finish_time.empty?,
+      "The `finish_time` field is missing from the results in these files:\n" +
+      finish_time.uniq.map { |file| "* #{file}" }.join("\n")
+  end
+
+  def test_time_formatting
+    offences = []
+    regex = /\d+m \d+s/
+
+    races.each do |filename|
+      yaml = YAML.load_file(filename)
+      if yaml.has_key?('results')
+        yaml['results'].each do |result|
+          next unless result.has_key?('finish_time')
+          offences << filename unless result['finish_time'].to_s.match(regex)
+        end
+      end
+    end
+
+    assert offences.empty?,
+      "The results times are in the wrong format, they should be 'XXm XXs'. These are the offending files:\n" +
+      offences.uniq.map { |file| "* #{file}" }.join("\n")
+  end
+end

--- a/tests/race_results_test.rb
+++ b/tests/race_results_test.rb
@@ -1,6 +1,20 @@
 require_relative "test_helper"
 
 class RaceResultsTest < Blog::Test
+  def has_time_field?(result)
+    result.has_key?('time') || result.has_key?('finish_time')
+  end
+
+  def time_field(result)
+    field = false
+    if result.has_key?('time')
+      field = 'time'
+    elsif result.has_key?('finish_time')
+      field = 'finish_time'
+    end
+    return field
+  end
+
   def test_correct_field_name
     finish_time = []
 
@@ -8,13 +22,13 @@ class RaceResultsTest < Blog::Test
       yaml = YAML.load_file(filename)
       if yaml.has_key?('results')
         yaml['results'].each do |result|
-          finish_time << filename unless result.has_key?('finish_time')
+          finish_time << filename unless has_time_field?(result)
         end
       end
     end
 
     assert finish_time.empty?,
-      "The `finish_time` field is missing from the results in these files:\n" +
+      "You need either a `time` or `finish_time` field in the results section of these files:\n" +
       finish_time.uniq.map { |file| "* #{file}" }.join("\n")
   end
 
@@ -26,8 +40,9 @@ class RaceResultsTest < Blog::Test
       yaml = YAML.load_file(filename)
       if yaml.has_key?('results')
         yaml['results'].each do |result|
-          next unless result.has_key?('finish_time')
-          offences << filename unless result['finish_time'].to_s.match(regex)
+          next unless has_time_field?(result)
+          field = time_field(result)
+          offences << filename unless result[field].to_s.match(regex)
         end
       end
     end


### PR DESCRIPTION
To make sure that results have the times in the expected manner, this PR adds a test to check for a `finish_time` field and make sure that it's in the right format (which is XXm XXs).