### PR TITLE
Includes JS files when they're needed

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -75,11 +75,12 @@
     </div>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="//blueimp.github.io/Gallery/js/jquery.blueimp-gallery.min.js"></script>
-    <script src="/assets/js/bootstrap.js"></script>
-    <script src="/assets/js/bootstrap-image-gallery.min.js"></script>
-    <script src="/assets/js/lunr.min.js"></script>
     <script src="/assets/js/search.js"></script>
-    <script src="/assets/js/results.js"></script>
+    {% if page.custom_js %}
+    {% for js_file in page.custom_js %}
+    <script src='/assets/js/{{ js_file }}.js' type="text/javascript"></script>
+    {% endfor %}
+    {% endif %}
     {% if jekyll.environment == "production" %}
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/gallery/index.html
+++ b/gallery/index.html
@@ -4,6 +4,9 @@ title: Gallery
 redirect_from:
   - /pages/PhotoGallery/8/
   - /home.html/gallery/gallery/
+custom_js:
+  - bootstrap
+  - bootstrap-image-gallery.min
 ---
 
 <div class="row">

--- a/search/index.html
+++ b/search/index.html
@@ -1,6 +1,9 @@
 ---
 layout: base
 title: Search Results
+custom_js:
+  - lunr.min
+  - results
 ---
 
 <div class="row">


### PR DESCRIPTION
Instead of loading javascript files on every page, this PR allows custom JS to be configured in the header of any page so that it's only included in that page.