### PR TITLE
Suggests a change in wording for the privacy link

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -64,7 +64,7 @@
         <div class="col-md-8">
           <p>Liffey Valley Athletic Club, Sandpitts Cottage, Islandbridge, Dublin 8</p>
           <p>Contact: Club Secretary, Orla Gordon lvacsecretary@gmail.com</p>
-          <p>Club privacy statement can be found <a href="http://liffeyvalleyac.com/privacy/">here</a></p>
+          <p><a href="http://liffeyvalleyac.com/privacy/">Club privacy statememnt</a></p>
         </div>
         <div class="col-md-4">
           <form class="search">


### PR DESCRIPTION
Instead of linking the word "here", this PR changes the link to "Club privacy statement" which is better for accessibility and is recommended in a lot of articles on how to create links. @hootsmin What do you think, would this be a good change?